### PR TITLE
add tag for Instance Name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_instance" "masters" {
   key_name = "${var.key_name}"
 
   tags = {
-    Name = "${var.instance_name_prefix}-master"
+    Name = "master-${var.instance_name_prefix}-${random_string.suffix.result}"
   }
 
   root_block_device {
@@ -46,7 +46,7 @@ resource "aws_instance" "workers" {
   key_name = "${var.key_name}"
 
   tags = {
-    Name = "${var.instance_name_prefix}-wrker"
+    Name = "wrker-${var.instance_name_prefix}-${random_string.suffix.result}"
   }
 
   root_block_device {

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_instance" "workers" {
   key_name = "${var.key_name}"
 
   tags = {
-    Name = "wrker-${var.instance_name_prefix}-${random_string.suffix.result}"
+    Name = "worker-${var.instance_name_prefix}-${random_string.suffix.result}"
   }
 
   root_block_device {

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,10 @@ resource "aws_instance" "masters" {
   vpc_security_group_ids = ["${aws_security_group.allow_ssh.id}"]
   key_name = "${var.key_name}"
 
+  tags = {
+    Name = "${var.instance_name_prefix}-master"
+  }
+
   root_block_device {
     volume_size = var.volume_size
     volume_type = var.volume_type
@@ -40,6 +44,10 @@ resource "aws_instance" "workers" {
   subnet_id = module.vpc.public_subnets[0]
   vpc_security_group_ids = ["${aws_security_group.allow_ssh.id}"]
   key_name = "${var.key_name}"
+
+  tags = {
+    Name = "${var.instance_name_prefix}-wrker"
+  }
 
   root_block_device {
     volume_size = var.volume_size


### PR DESCRIPTION
add tag for Instance Name - this will add the instance_name_prefix and add the `master` or `wrker` to the name of the EC2 instance in the Console.